### PR TITLE
fix: parallelogram overlay not correct bug.

### DIFF
--- a/src/extension/parallelogram.ts
+++ b/src/extension/parallelogram.ts
@@ -36,7 +36,7 @@ const parallelogram: OverlayTemplate = {
       ]
     }
     if (coordinates.length === 3) {
-      const coordinate = { x: coordinates[0].x + (coordinates[2].x - coordinates[1].x), y: coordinates[2].y }
+      const coordinate = { x: coordinates[0].x + coordinates[2].x - coordinates[1].x, y: coordinates[0].y + coordinates[2].y - coordinates[1].y }
       return [
         {
           type: 'polygon',


### PR DESCRIPTION
previous:
![Screenshot 2023-12-11 at 10 46 30](https://github.com/klinecharts/pro/assets/25810389/9aa246c8-0e71-45bb-b5b3-db199f196205)

now:
![Screenshot 2023-12-11 at 10 48 06](https://github.com/klinecharts/pro/assets/25810389/4a3578c5-6ff8-454b-9110-523e5d506346)

reason:
the fourth point's y-coordinate calculation is not correct.